### PR TITLE
feat: add edit spelling session button on swipe-left

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import Sessions from "@/pages/sessions";
 import Settings from "@/pages/settings";
 import CreateSession from "@/pages/create-session";
 import PracticeSession from "@/pages/practice-session";
+import EditSession from "@/pages/edit-session";
 import NotFound from "@/pages/not-found";
 import BottomNavigation from "@/components/bottom-navigation";
 
@@ -21,6 +22,7 @@ function Router() {
           <Route path="/settings" component={Settings} />
           <Route path="/create-session" component={CreateSession} />
           <Route path="/practice/:id" component={PracticeSession} />
+          <Route path="/edit-session/:id" component={EditSession} />
           <Route component={NotFound} />
         </Switch>
       </div>

--- a/client/src/components/swipeable-card.tsx
+++ b/client/src/components/swipeable-card.tsx
@@ -1,24 +1,27 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Trash2 } from 'lucide-react';
+import { Trash2, Pencil } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 
 interface SwipeableCardProps {
   children: React.ReactNode;
   onDelete: () => void;
+  onEdit?: () => void;
   className?: string;
   'data-testid'?: string;
 }
 
-export function SwipeableCard({ children, onDelete, className = '', 'data-testid': testId }: SwipeableCardProps) {
+export function SwipeableCard({ children, onDelete, onEdit, className = '', 'data-testid': testId }: SwipeableCardProps) {
+  const BUTTON_WIDTH = 80;
+  const TOTAL_ACTION_WIDTH = onEdit ? BUTTON_WIDTH * 2 : BUTTON_WIDTH;
+  const SWIPE_THRESHOLD = TOTAL_ACTION_WIDTH * 0.5;
+
   const [translateX, setTranslateX] = useState(0);
   const [isRevealed, setIsRevealed] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const startX = useRef(0);
   const currentX = useRef(0);
-  const DELETE_BUTTON_WIDTH = 80; // Width of the delete button area
-  const SWIPE_THRESHOLD = DELETE_BUTTON_WIDTH * 0.5; // Threshold to auto-reveal delete button
 
   const handleTouchStart = (e: React.TouchEvent) => {
     setIsDragging(true);
@@ -28,20 +31,15 @@ export function SwipeableCard({ children, onDelete, className = '', 'data-testid
 
   const handleTouchMove = (e: React.TouchEvent) => {
     if (!isDragging) return;
-    
-    const clientX = e.touches[0].clientX;
-    const deltaX = startX.current - clientX; // Positive when swiping left
-    const newTranslateX = Math.max(0, Math.min(DELETE_BUTTON_WIDTH, currentX.current + deltaX));
-    
+    const deltaX = startX.current - e.touches[0].clientX;
+    const newTranslateX = Math.max(0, Math.min(TOTAL_ACTION_WIDTH, currentX.current + deltaX));
     setTranslateX(newTranslateX);
   };
 
   const handleTouchEnd = () => {
     setIsDragging(false);
-    
-    // Snap to revealed or closed state based on threshold
     if (translateX > SWIPE_THRESHOLD) {
-      setTranslateX(DELETE_BUTTON_WIDTH);
+      setTranslateX(TOTAL_ACTION_WIDTH);
       setIsRevealed(true);
     } else {
       setTranslateX(0);
@@ -53,26 +51,20 @@ export function SwipeableCard({ children, onDelete, className = '', 'data-testid
     setIsDragging(true);
     startX.current = e.clientX;
     currentX.current = translateX;
-    
-    // Prevent text selection while dragging
     e.preventDefault();
   };
 
   const handleMouseMove = (e: MouseEvent) => {
     if (!isDragging) return;
-    
-    const deltaX = startX.current - e.clientX; // Positive when swiping left
-    const newTranslateX = Math.max(0, Math.min(DELETE_BUTTON_WIDTH, currentX.current + deltaX));
-    
+    const deltaX = startX.current - e.clientX;
+    const newTranslateX = Math.max(0, Math.min(TOTAL_ACTION_WIDTH, currentX.current + deltaX));
     setTranslateX(newTranslateX);
   };
 
   const handleMouseUp = () => {
     setIsDragging(false);
-    
-    // Snap to revealed or closed state based on threshold
     if (translateX > SWIPE_THRESHOLD) {
-      setTranslateX(DELETE_BUTTON_WIDTH);
+      setTranslateX(TOTAL_ACTION_WIDTH);
       setIsRevealed(true);
     } else {
       setTranslateX(0);
@@ -86,6 +78,13 @@ export function SwipeableCard({ children, onDelete, className = '', 'data-testid
     onDelete();
   };
 
+  const handleEditClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    resetCard();
+    onEdit?.();
+  };
+
   const resetCard = () => {
     setTranslateX(0);
     setIsRevealed(false);
@@ -96,7 +95,6 @@ export function SwipeableCard({ children, onDelete, className = '', 'data-testid
     if (isDragging) {
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
-      
       return () => {
         document.removeEventListener('mousemove', handleMouseMove);
         document.removeEventListener('mouseup', handleMouseUp);
@@ -111,13 +109,12 @@ export function SwipeableCard({ children, onDelete, className = '', 'data-testid
         resetCard();
       }
     };
-
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [isRevealed]);
 
   return (
-    <div 
+    <div
       ref={cardRef}
       className="relative overflow-hidden"
       data-testid={testId}
@@ -136,18 +133,30 @@ export function SwipeableCard({ children, onDelete, className = '', 'data-testid
         </Card>
       </div>
 
-      {/* Delete button revealed on swipe */}
-      <div 
-        className="absolute top-0 right-0 h-full flex items-center justify-center bg-red-500 text-white"
-        style={{ 
-          width: `${DELETE_BUTTON_WIDTH}px`,
-          transform: `translateX(${DELETE_BUTTON_WIDTH - translateX}px)`,
+      {/* Action buttons revealed on swipe */}
+      <div
+        className="absolute top-0 right-0 h-full flex items-stretch"
+        style={{
+          width: `${TOTAL_ACTION_WIDTH}px`,
+          transform: `translateX(${TOTAL_ACTION_WIDTH - translateX}px)`,
+          transition: isDragging ? 'none' : 'transform 300ms ease-out',
         }}
       >
+        {onEdit && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-full flex-1 bg-indigo-500 text-white hover:bg-indigo-600 hover:text-white rounded-none flex flex-col items-center justify-center gap-1"
+            onClick={handleEditClick}
+            data-testid={testId ? `${testId}-edit` : undefined}
+          >
+            <Pencil className="h-5 w-5" />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
-          className="h-full w-full text-white hover:bg-red-600 hover:text-white rounded-none"
+          className="h-full flex-1 bg-red-500 text-white hover:bg-red-600 hover:text-white rounded-none flex flex-col items-center justify-center gap-1"
           onClick={handleDeleteClick}
           data-testid={testId ? `${testId}-delete` : undefined}
         >

--- a/client/src/pages/edit-session.tsx
+++ b/client/src/pages/edit-session.tsx
@@ -1,0 +1,237 @@
+import { useState, useEffect } from "react";
+import { useLocation, useParams } from "wouter";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { ArrowLeft, Plus, Trash2, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import { queryClient } from "@/lib/queryClient";
+import type { Session } from "@shared/schema";
+
+export default function EditSession() {
+  const { id } = useParams<{ id: string }>();
+  const [, navigate] = useLocation();
+  const { toast } = useToast();
+
+  const [sessionTitle, setSessionTitle] = useState("");
+  const [words, setWords] = useState<string[]>([""]);
+  const [isSaved, setIsSaved] = useState(false);
+
+  // Fetch the existing session
+  const { data: session, isLoading } = useQuery<Session>({
+    queryKey: [`/api/sessions/${id}`],
+    enabled: !!id,
+  });
+
+  // Pre-populate form once session loads
+  useEffect(() => {
+    if (session) {
+      setSessionTitle(session.title);
+      setWords(session.words.length > 0 ? session.words : [""]);
+    }
+  }, [session]);
+
+  const updateSessionMutation = useMutation({
+    mutationFn: async (payload: { title: string; words: string[]; wordCount: number }) => {
+      const response = await fetch(`/api/sessions/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error("Failed to update session");
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/sessions"] });
+      queryClient.invalidateQueries({ queryKey: [`/api/sessions/${id}`] });
+      setIsSaved(true);
+      setTimeout(() => {
+        navigate("/sessions");
+      }, 1500);
+    },
+    onError: () => {
+      toast({
+        title: "Error",
+        description: "Failed to save changes. Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const handleAddWord = () => {
+    setWords([...words, ""]);
+  };
+
+  const handleRemoveWord = (index: number) => {
+    setWords(words.filter((_, i) => i !== index));
+  };
+
+  const handleWordChange = (index: number, value: string) => {
+    const updated = [...words];
+    updated[index] = value;
+    setWords(updated);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, index: number) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (index === words.length - 1 && words[index].trim().length > 0) {
+        handleAddWord();
+        setTimeout(() => {
+          const newInput = document.querySelector(
+            `[data-testid="edit-input-word-${words.length}"]`
+          ) as HTMLInputElement;
+          if (newInput) newInput.focus();
+        }, 50);
+      } else if (index < words.length - 1) {
+        const nextInput = document.querySelector(
+          `[data-testid="edit-input-word-${index + 1}"]`
+        ) as HTMLInputElement;
+        if (nextInput) nextInput.focus();
+      }
+    }
+  };
+
+  const handleSave = () => {
+    const filteredWords = words.filter((w) => w.trim().length > 0);
+    if (filteredWords.length === 0) {
+      toast({
+        title: "No words",
+        description: "Please add at least one word before saving.",
+        variant: "destructive",
+      });
+      return;
+    }
+    const title = sessionTitle.trim() || `Spelling Session ${new Date().toLocaleDateString()}`;
+    updateSessionMutation.mutate({ title, words: filteredWords, wordCount: filteredWords.length });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="fade-in">
+        <div className="px-4 py-6 bg-card border-b border-border">
+          <div className="flex items-center space-x-3">
+            <Button variant="ghost" size="sm" onClick={() => navigate("/sessions")} className="p-2">
+              <ArrowLeft className="w-5 h-5" />
+            </Button>
+            <h1 className="text-xl font-semibold text-foreground">Edit Session</h1>
+          </div>
+        </div>
+        <div className="px-4 py-6 space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <Card key={i} className="animate-pulse">
+              <CardContent className="p-4">
+                <div className="h-4 bg-muted rounded w-3/4 mb-2" />
+                <div className="h-3 bg-muted rounded w-1/2" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isSaved) {
+    return (
+      <div className="fade-in px-4 py-12 flex flex-col items-center justify-center text-center">
+        <div className="w-16 h-16 bg-primary rounded-full flex items-center justify-center mb-6">
+          <Check className="w-8 h-8 text-primary-foreground" />
+        </div>
+        <h1 className="text-2xl font-bold text-foreground mb-2">Session Updated!</h1>
+        <p className="text-muted-foreground mb-8 max-w-sm">
+          Your changes have been saved. Returning to sessions list…
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fade-in">
+      {/* Header */}
+      <div className="px-4 py-6 bg-card border-b border-border">
+        <div className="flex items-center space-x-3">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate("/sessions")}
+            className="p-2"
+            data-testid="button-edit-go-back"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </Button>
+          <h1 className="text-xl font-semibold text-foreground">Edit Session</h1>
+        </div>
+      </div>
+
+      {/* Form */}
+      <div className="px-4 py-6">
+        <div className="mb-6">
+          <h2 className="text-lg font-semibold text-foreground mb-2">Session Details</h2>
+          <p className="text-sm text-muted-foreground">
+            Update the title and word list for this session.
+          </p>
+        </div>
+
+        {/* Session Title */}
+        <div className="mb-6">
+          <Input
+            placeholder="Session title"
+            value={sessionTitle}
+            onChange={(e) => setSessionTitle(e.target.value)}
+            className="w-full"
+            data-testid="edit-input-session-title"
+          />
+        </div>
+
+        {/* Word List */}
+        <div className="space-y-3 mb-6">
+          {words.map((word, index) => (
+            <div
+              key={index}
+              className="flex items-center space-x-3 p-3 bg-card rounded-lg border border-border"
+            >
+              <span className="w-6 text-sm text-muted-foreground">{index + 1}.</span>
+              <Input
+                value={word}
+                onChange={(e) => handleWordChange(index, e.target.value)}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+                className="flex-1 bg-transparent border-none outline-none"
+                placeholder="Enter word…"
+                data-testid={`edit-input-word-${index}`}
+              />
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleRemoveWord(index)}
+                className="p-1 text-destructive hover:bg-destructive/10"
+                data-testid={`edit-button-remove-word-${index}`}
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <Button
+          variant="outline"
+          onClick={handleAddWord}
+          className="w-full mb-4"
+          data-testid="edit-button-add-word"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          Add Word
+        </Button>
+
+        <Button
+          onClick={handleSave}
+          className="w-full"
+          disabled={updateSessionMutation.isPending}
+          data-testid="edit-button-save"
+        >
+          {updateSessionMutation.isPending ? "Saving…" : "Save Changes"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/sessions.tsx
+++ b/client/src/pages/sessions.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { Plus, ChevronRight, Calendar, FileText, Pin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -11,6 +11,7 @@ import { format } from "date-fns";
 
 export default function Sessions() {
   const queryClient = useQueryClient();
+  const [, navigate] = useLocation();
   const { data: sessions = [], isLoading } = useQuery<Session[]>({
     queryKey: ["/api/sessions"],
   });
@@ -111,8 +112,8 @@ export default function Sessions() {
       <div className="px-4 py-4">
         {/* Create New Session Button */}
         <div className="mb-6">
-          <Button 
-            asChild 
+          <Button
+            asChild
             className="w-full flex items-center justify-between p-4 h-auto bg-card text-foreground border border-border hover:shadow-md"
             variant="outline"
             data-testid="button-create-session"
@@ -165,6 +166,7 @@ export default function Sessions() {
                   className="word-card hover:shadow-md transition-shadow cursor-pointer"
                   data-testid={`card-session-${session.id}`}
                   onDelete={() => handleDeleteSession(session.id)}
+                  onEdit={() => navigate(`/edit-session/${session.id}`)}
                 >
                   <Link href={`/practice/${session.id}`}>
                     <CardContent className="p-4">


### PR DESCRIPTION
- Add onEdit prop to SwipeableCard; reveals indigo Edit + red Delete buttons side-by-side
- Wire onEdit in sessions.tsx to navigate to /edit-session/:id
- New edit-session.tsx page pre-populates title and word list from existing session, saves via PUT /api/sessions/:id
- Register /edit-session/:id route in App.tsx