### PR TITLE
Rename Test/Practice tabs to Write/Read

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+# Spelling Pro
+
+A mobile-first spelling practice app: users capture spelling worksheets via camera/OCR, then work through the extracted words in a practice session.
+
+## Language
+
+**Write Mode**:
+The session mode where a word is played aloud (dictation), hidden from view, and the user writes it down off-app. Repeats the word per the configured repetition count.
+_Avoid_: Test, test mode
+
+**Read Mode**:
+The session mode where the word is displayed on screen for the user to read, with an optional audio playback and no repetition. Currently a static display; not yet an interactive reading exercise.
+_Avoid_: Practice, practice mode

--- a/client/src/pages/practice-session.tsx
+++ b/client/src/pages/practice-session.tsx
@@ -12,13 +12,13 @@ import { apiRequest } from "@/lib/queryClient";
 import { queryClient } from "@/lib/queryClient";
 import type { Session, Settings } from "@shared/schema";
 
-type PracticeMode = "practice" | "test";
+type SessionViewMode = "read" | "write";
 
 export default function PracticeSession() {
   const { id } = useParams<{ id: string }>();
   const [, navigate] = useLocation();
   const { toast } = useToast();
-  const [mode, setMode] = useState<PracticeMode>("test");
+  const [mode, setMode] = useState<SessionViewMode>("write");
   const [currentWordIndex, setCurrentWordIndex] = useState(0);
   const [currentRepetition, setCurrentRepetition] = useState(1);
   const [wordsCompleted, setWordsCompleted] = useState<Set<number>>(new Set());
@@ -145,7 +145,7 @@ export default function PracticeSession() {
 
   
   // This is the main playWord function
-  // It handles the logic for playing a word, including repetitions in test mode
+  // It handles the logic for playing a word, including repetitions in write mode
 
   const playWord = async (repetitionCount: number = 1) => {
     if (!session || isMuted) return;
@@ -207,14 +207,14 @@ export default function PracticeSession() {
       });
 
       // Use the ref value which updates immediately, not the state which is stale
-      if (isPausedRef.current || isMuted || mode !== "test") {
+      if (isPausedRef.current || isMuted || mode !== "write") {
         console.log('❌ NOT SCHEDULING - state changed during speech (using ref)');
         setIsLooping(false);
         return; // Exit early, don't schedule timeout
       }
 
-      // Handle repetitions in test mode (use effective settings fallback)
-      if (mode === "test") {
+      // Handle repetitions in write mode (use effective settings fallback)
+      if (mode === "write") {
         const maxRepetitions = effectiveSettings.wordRepetitions;
         const pauseDuration = effectiveSettings.pauseBetweenWords;
 
@@ -236,7 +236,7 @@ export default function PracticeSession() {
             });
 
             // Check ref value in timeout as well
-            if (mode === "test" && !isMuted && !isPausedRef.current) {
+            if (mode === "write" && !isMuted && !isPausedRef.current) {
               console.log(`🔄 NEXT REPETITION (${repetitionCount + 1}/${maxRepetitions})`);
               playWord(repetitionCount + 1);
             } else {
@@ -326,7 +326,7 @@ export default function PracticeSession() {
     setWordsCompleted(prev => new Set(Array.from(prev).concat(currentWordIndex)));
   };
 
-  const switchMode = (newMode: PracticeMode) => {
+  const switchMode = (newMode: SessionViewMode) => {
     // Force stop all speech immediately and reset state
     stopAllPlayback();
     setIsPaused(true);
@@ -403,16 +403,16 @@ export default function PracticeSession() {
         </div>
 
         {/* Mode Toggle */}
-        <Tabs value={mode} onValueChange={(value) => switchMode(value as PracticeMode)} className="mt-4">
+        <Tabs value={mode} onValueChange={(value) => switchMode(value as SessionViewMode)} className="mt-4">
           <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="test" data-testid="tab-test">Test</TabsTrigger>
-            <TabsTrigger value="practice" data-testid="tab-practice">Practice</TabsTrigger>
+            <TabsTrigger value="write" data-testid="tab-write">Write</TabsTrigger>
+            <TabsTrigger value="read" data-testid="tab-read">Read</TabsTrigger>
           </TabsList>
         </Tabs>
       </div>
 
-      {/* Practice Mode Content */}
-      {mode === "practice" && (
+      {/* Read Mode Content */}
+      {mode === "read" && (
         <div className="px-4 py-8">
           {/* Word Display */}
           <div className="text-center mb-8">
@@ -502,8 +502,8 @@ export default function PracticeSession() {
         </div>
       )}
 
-      {/* Test Mode Content */}
-      {mode === "test" && (
+      {/* Write Mode Content */}
+      {mode === "write" && (
         <div className="px-4 py-8">
           {/* Word Display Hidden */}
           <div className="text-center mb-8">

--- a/client/src/pages/settings.tsx
+++ b/client/src/pages/settings.tsx
@@ -254,7 +254,7 @@ export default function SettingsPage() {
                 <div>
                   <Label className="font-medium">Word Repetitions</Label>
                   <p className="text-sm text-muted-foreground">
-                    Adjust how many times a word is read aloud during practice.
+                    Adjust how many times a word is read aloud during write mode.
                   </p>
                 </div>
                 <span className="text-foreground font-medium" data-testid="text-repetitions-value">
@@ -362,7 +362,7 @@ export default function SettingsPage() {
               <div>
                 <Label className="font-medium">Show Pause Button</Label>
                 <p className="text-sm text-muted-foreground">
-                  Display pause/resume button during test mode dictation.
+                  Display pause/resume button during write mode dictation.
                 </p>
               </div>
               <Switch

--- a/replit.md
+++ b/replit.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Spelling Pro is a Progressive Web Application (PWA) designed as a mobile-first spelling practice tool specifically optimized for iPhone. The application enables users to capture images of spelling worksheets using their device camera, extract text using OCR (Optical Character Recognition), and create interactive spelling practice sessions. The app features both practice and test modes with audio playback capabilities for enhanced learning.
+Spelling Pro is a Progressive Web Application (PWA) designed as a mobile-first spelling practice tool specifically optimized for iPhone. The application enables users to capture images of spelling worksheets using their device camera, extract text using OCR (Optical Character Recognition), and create interactive spelling practice sessions. The app features both Read and Write modes with audio playback capabilities for enhanced learning.
 
 The application follows a camera-to-practice workflow: users photograph spelling worksheets, the app processes the images to extract individual words, users can edit and curate the word list, and finally engage in structured spelling practice sessions with customizable audio feedback and timing controls.
 


### PR DESCRIPTION
## Summary
- Renames the session tabs from "Test"/"Practice" to "Write"/"Read" (CHE-9), including backing identifiers (`PracticeMode` -> `SessionViewMode`, `"test"/"practice"` -> `"write"/"read"`, `data-testid` attributes)
- Updates dependent copy in settings.tsx and replit.md
- Adds a CONTEXT.md glossary defining "Write Mode" / "Read Mode"

Out of scope (per CHE-9): file name/route/component name (`practice-session.tsx`, `/practice/:id`, `PracticeSession`), and the reading-practice flashcard redesign (tracked in CHE-14).

## Test plan
- [x] `npm run check` passes
- [x] Verified in browser: Write tab shows dictation UI, Read tab shows word display, both function as before under new names
- [x] Code review (Standards + Spec axes) run, one naming finding resolved (`SessionMode` -> `SessionViewMode`), no spec deviations

Closes CHE-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)