### PR TITLE
Split Read into Read/Peek tabs to test reading recall (CHE-16)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,9 +9,13 @@ The session mode where a word is played aloud (dictation), hidden from view, and
 _Avoid_: Test, test mode
 
 **Read Mode**:
-The session mode where the word is displayed on screen for the user to read, with an optional audio playback and no repetition. Currently a static display; not yet an interactive reading exercise.
+The session mode where the word is displayed on screen for the user to read aloud, with no pinyin, no audio playback, and no repetition — a recall test. Session-scoped mastery marking ("I've Got This") happens here.
 _Avoid_: Practice, practice mode
 
+**Peek Mode**:
+The session mode where the word is displayed alongside its Pinyin Annotation and an audio playback button, for checking a Read Mode guess. Has no "I've Got This" marking of its own — mastery is only ever recorded from Read Mode. Hidden from the tab bar whenever the current word has no Pinyin Annotation (e.g. an English word in a mixed-language session).
+_Avoid_: Test, test mode, Check mode
+
 **Pinyin Annotation**:
-The auto-detected, auto-generated romanization line shown below a word in Read Mode whenever the word contains Chinese characters. Computed at render time from the word's stored text — never typed in by the user or persisted.
+The auto-detected, auto-generated romanization line shown below a word in Peek Mode whenever the word contains Chinese characters. Computed at render time from the word's stored text — never typed in by the user or persisted.
 _Avoid_: Translation, transliteration

--- a/client/src/lib/session-mode.test.ts
+++ b/client/src/lib/session-mode.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { resolveSessionViewMode } from "./session-mode";
+
+describe("resolveSessionViewMode", () => {
+  it("keeps the current mode when the word has pinyin to peek at", () => {
+    expect(resolveSessionViewMode("peek", true)).toBe("peek");
+    expect(resolveSessionViewMode("read", true)).toBe("read");
+    expect(resolveSessionViewMode("write", true)).toBe("write");
+  });
+
+  it("falls back to read when on peek for a word with no pinyin", () => {
+    expect(resolveSessionViewMode("peek", false)).toBe("read");
+  });
+
+  it("leaves write and read alone regardless of pinyin availability", () => {
+    expect(resolveSessionViewMode("write", false)).toBe("write");
+    expect(resolveSessionViewMode("read", false)).toBe("read");
+  });
+});

--- a/client/src/lib/session-mode.ts
+++ b/client/src/lib/session-mode.ts
@@ -1,0 +1,13 @@
+export type SessionViewMode = "read" | "write" | "peek";
+
+/**
+ * Peek has nothing to show for a word with no pinyin, so if the current
+ * word changes out from under an open Peek tab, fall back to Read.
+ */
+export function resolveSessionViewMode(
+  mode: SessionViewMode,
+  currentWordHasPinyin: boolean,
+): SessionViewMode {
+  if (mode === "peek" && !currentWordHasPinyin) return "read";
+  return mode;
+}

--- a/client/src/pages/practice-session.tsx
+++ b/client/src/pages/practice-session.tsx
@@ -21,9 +21,8 @@ import { useSpeech } from "@/hooks/use-speech";
 import { apiRequest } from "@/lib/queryClient";
 import { queryClient } from "@/lib/queryClient";
 import { getPinyinAnnotation } from "@/lib/pinyin";
+import { resolveSessionViewMode, type SessionViewMode } from "@/lib/session-mode";
 import type { Session, Settings } from "@shared/schema";
-
-type SessionViewMode = "read" | "write";
 
 export default function PracticeSession() {
   const { id } = useParams<{ id: string }>();
@@ -130,6 +129,14 @@ export default function PracticeSession() {
 
     return () => clearInterval(interval);
   }, [sessionStartTime]);
+
+  // Peek has nothing to show for a word with no pinyin (e.g. English words
+  // in a mixed-language session) - fall back to Read if the word changes
+  // out from under an open Peek tab.
+  const currentWordPinyin = session ? getPinyinAnnotation(session.words[currentWordIndex]) : null;
+  useEffect(() => {
+    setMode((prev) => resolveSessionViewMode(prev, currentWordPinyin !== null));
+  }, [currentWordPinyin]);
 
   // ✅ ADD THE DEBUGGING useEffect RIGHT HERE:
   useEffect(() => {
@@ -431,7 +438,6 @@ export default function PracticeSession() {
   }
 
   const currentWord = session.words[currentWordIndex];
-  const currentWordPinyin = getPinyinAnnotation(currentWord);
   const progressPercentage = Math.floor((sessionSkipped.size / session.words.length) * 100);
   const allWordsSkipped = session.words.length > 0 && sessionSkipped.size === session.words.length;
   const isCurrentWordSkipped = sessionSkipped.has(currentWordIndex);
@@ -493,15 +499,18 @@ export default function PracticeSession() {
 
         {/* Mode Toggle */}
         <Tabs value={mode} onValueChange={(value) => switchMode(value as SessionViewMode)} className="mt-4">
-          <TabsList className="grid w-full grid-cols-2">
+          <TabsList className={`grid w-full ${currentWordPinyin ? "grid-cols-3" : "grid-cols-2"}`}>
             <TabsTrigger value="write" data-testid="tab-write">Write</TabsTrigger>
             <TabsTrigger value="read" data-testid="tab-read">Read</TabsTrigger>
+            {currentWordPinyin && (
+              <TabsTrigger value="peek" data-testid="tab-peek">Peek</TabsTrigger>
+            )}
           </TabsList>
         </Tabs>
       </div>
 
-      {/* Read Mode Content */}
-      {mode === "read" && (
+      {/* Read / Peek Mode Content */}
+      {(mode === "read" || mode === "peek") && (
         <div className="px-4 py-8">
           {allWordsSkipped ? (
             /* All words marked with "I've Got This" for this session */
@@ -521,13 +530,13 @@ export default function PracticeSession() {
           /* Word Display */
           <div className="text-center mb-8">
             <div
-              className={`text-4xl font-bold text-foreground ${currentWordPinyin ? "" : "mb-6"}`}
+              className={`text-4xl font-bold text-foreground ${mode === "peek" && currentWordPinyin ? "" : "mb-6"}`}
               data-testid="text-current-word"
             >
               {currentWord}
             </div>
 
-            {currentWordPinyin && (
+            {mode === "peek" && currentWordPinyin && (
               <div className="text-lg text-muted-foreground mb-6" data-testid="text-current-word-pinyin">
                 {currentWordPinyin}
               </div>
@@ -540,18 +549,20 @@ export default function PracticeSession() {
             )}
 
             {/* Audio Controls */}
-            <div className="flex items-center justify-center space-x-4 mb-8">
-              <Button
-                variant="outline"
-                size="lg"
-                className="p-3 rounded-full"
-                onClick={() => playWord(1)}
-                disabled={isMuted}
-                data-testid="button-play-audio"
-              >
-                <Volume2 className="w-6 h-6" />
-              </Button>
-            </div>
+            {mode === "peek" && (
+              <div className="flex items-center justify-center space-x-4 mb-8">
+                <Button
+                  variant="outline"
+                  size="lg"
+                  className="p-3 rounded-full"
+                  onClick={() => playWord(1)}
+                  disabled={isMuted}
+                  data-testid="button-play-audio"
+                >
+                  <Volume2 className="w-6 h-6" />
+                </Button>
+              </div>
+            )}
 
             {/* Navigation Controls */}
             <div className="flex items-center justify-center space-x-6 mb-6">
@@ -582,9 +593,11 @@ export default function PracticeSession() {
               {currentWordIndex + 1}/{session.words.length} words
             </div>
 
-            <Button onClick={handleIveGotThis} data-testid="button-mark-completed">
-              I've Got This
-            </Button>
+            {mode === "read" && (
+              <Button onClick={handleIveGotThis} data-testid="button-mark-completed">
+                I've Got This
+              </Button>
+            )}
           </div>
           )}
 


### PR DESCRIPTION
## Summary
- Splits the Read tab into two: Read (recall test — character only, no pinyin, no playback) and Peek (validator — character + pinyin + playback, no "I've Got This")
- Peek tab is hidden per-word when there's no pinyin to show (e.g. English words), falling back to Read if the word changes out from under an open Peek tab
- "I've Got This" mastery marking stays Read-only and independent of Peek, per CHE-16 spec

Closes CHE-16

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` — 10/10 tests pass, including new `session-mode.test.ts` covering the Peek→Read fallback logic
- [x] Manually verified in browser: three tabs render, Read hides pinyin/playback, Peek hides "I've Got This", Peek tab disappears for English-only words

🤖 Generated with [Claude Code](https://claude.com/claude-code)