### PR TITLE
Fix camera capture never launching (CHE-18)

### DIFF
--- a/client/src/components/camera-capture.tsx
+++ b/client/src/components/camera-capture.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Camera } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useCamera } from "@/hooks/use-camera";
@@ -15,11 +15,27 @@ export default function CameraCapture({ onImageCapture, onSkip }: CameraCaptureP
   
   const { startCamera, stopCamera, capturePhoto, error } = useCamera(videoRef);
 
-  const handleStartCamera = async () => {
-    const success = await startCamera();
-    if (success) {
-      setIsCameraActive(true);
-    }
+  // The <video> only exists once the camera UI is showing, so flip the UI on
+  // first and attach the stream afterwards — starting the camera before the
+  // element is mounted leaves videoRef null and the preview never appears.
+  useEffect(() => {
+    if (!isCameraActive) return;
+
+    let cancelled = false;
+    startCamera().then((success) => {
+      if (!success && !cancelled) setIsCameraActive(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isCameraActive]);
+
+  // Release the camera if we navigate away mid-capture.
+  useEffect(() => stopCamera, []);
+
+  const handleStartCamera = () => {
+    setIsCameraActive(true);
   };
 
   const handleCapture = async () => {

--- a/client/src/hooks/use-camera.tsx
+++ b/client/src/hooks/use-camera.tsx
@@ -7,6 +7,15 @@ export function useCamera(videoRef: React.RefObject<HTMLVideoElement>) {
   const startCamera = async (): Promise<boolean> => {
     try {
       setError(null);
+      if (!navigator.mediaDevices?.getUserMedia) {
+        // getUserMedia only exists in a secure context — http:// over a LAN
+        // address (e.g. testing on a phone against the dev server) won't have it.
+        setError(
+          "Camera unavailable. The camera only works over HTTPS or on localhost.",
+        );
+        return false;
+      }
+
       const stream = await navigator.mediaDevices.getUserMedia({
         video: {
           facingMode: { ideal: "environment" }, // Use back camera if available
@@ -14,13 +23,22 @@ export function useCamera(videoRef: React.RefObject<HTMLVideoElement>) {
           height: { ideal: 720 },
         },
       });
-      
-      if (videoRef.current) {
-        videoRef.current.srcObject = stream;
-        streamRef.current = stream;
-        return true;
+
+      streamRef.current = stream;
+
+      if (!videoRef.current) {
+        // Nothing to attach the stream to — release the camera rather than
+        // leaving it running with the indicator light on.
+        stopCamera();
+        setError("Failed to start the camera preview. Please try again.");
+        return false;
       }
-      return false;
+
+      videoRef.current.srcObject = stream;
+      // iOS Safari doesn't reliably honour the autoplay attribute for a stream
+      // attached after mount, so start playback explicitly.
+      await videoRef.current.play().catch(() => {});
+      return true;
     } catch (err) {
       console.error("Error accessing camera:", err);
       setError("Failed to access camera. Please ensure camera permissions are granted.");

--- a/docs/adr/0002-server-proxy-for-image-extraction-no-persistence.md
+++ b/docs/adr/0002-server-proxy-for-image-extraction-no-persistence.md
@@ -1,0 +1,17 @@
+# Proxy image-to-spelling-list extraction through the existing server, without persisting the image
+
+CHE-17 needs the app to send a photographed worksheet to Claude for entity extraction and get back candidate spelling sessions. The ticket asks for this to happen "in the frontend, no backend server deployed," and separately requires secure token handling — two constraints that pull against each other, since the only way to call Claude directly from the browser is to ship an API key inside the client bundle.
+
+We're resolving this with a server-side proxy instead of a client-embedded key. A key baked into the Vite bundle is readable by anyone who opens devtools or inspects network requests — the app's PIN only gates in-app screens after the JS has already loaded, it does not gate the bundle itself, and Anthropic has no scoped/spend-limited client tokens the way e.g. Stripe or Firebase do. So there's no way to hand the browser a "safe" key.
+
+The app already has a deployed Express server (used for session CRUD) and already stores one secret as a Render environment variable (`DATABASE_URL`). Adding one route to that server, reading the Anthropic key from a second Render env var, means the key never reaches the browser while adding no new infrastructure or deployment — satisfying "no backend server deployed" as "no new backend," which is the only reading consistent with a backend already existing (see [0001](0001-pinyin-pro-for-client-side-pinyin.md) for the precedent of avoiding backend *compute cost*, not backend *existence*).
+
+The route is stateless: it relays the image bytes to Anthropic in memory and streams the JSON result back. Nothing is written to Postgres or disk. This was a specific requirement (not wanting to store captured images) and falls out naturally from the route just forwarding a request/response rather than persisting anything — the same lifecycle `POST /api/sessions` already has.
+
+The new endpoint has no auth in front of it, consistent with every other route in this API today. The only cost at stake is Claude spend on a single-user app served from an unlisted URL; PIN-gating this one endpoint would add friction to the most-used flow in the app for a risk that doesn't currently exist. Revisit if the URL is ever shared more widely.
+
+## Considered Options
+
+- **Direct browser-to-Anthropic call with a client-embedded key** — rejected: the key is extractable via devtools/network tab regardless of the app's PIN, and Anthropic has no way to scope or rate-limit a client-held key.
+- **Server-side proxy that persists the image and/or extraction result** — rejected: no product need to retain images, and persisting them adds storage and privacy surface for no benefit.
+- **Server-side proxy, stateless, key as a Render env var** (chosen) — keeps the key server-side, adds no new infra, stores nothing.


### PR DESCRIPTION
Fixes the camera capture in the create-session flow, which has never worked on any device. Unblocks CHE-21 (image-to-spelling-list capture).

## The bug

`handleStartCamera` called `startCamera()` **before** setting `isCameraActive`, but the `<video>` element only renders *when* `isCameraActive` is true. So `videoRef.current` was always `null` at that point, `startCamera` hit its `if (videoRef.current)` guard, returned `false`, and `setIsCameraActive(true)` never ran.

The preview could never appear — this wasn't flaky, it was unwinnable. It also leaked: `getUserMedia` had already resolved by the time the guard failed, so the stream stayed open with no reference kept to stop it, leaving the camera indicator lit.

## What changed

- **Mount the video first, attach the stream after.** `isCameraActive` flips on click; an effect starts the camera once the element exists, and reverts to the inactive state if it fails.
- **Release the camera when there's nothing to attach to**, instead of leaking the stream.
- **Stop the stream on unmount**, so navigating away mid-capture doesn't leave the camera running.
- **Call `play()` explicitly.** iOS Safari doesn't reliably honour the autoplay attribute for a stream attached after mount.
- **Detect missing `mediaDevices` up front**, so a failure in an insecure context reads as "only works over HTTPS or on localhost" rather than a misleading permissions error. This is a plausible *second* independent reason it appeared broken — testing on a phone against the dev server over `http://<lan-ip>:5001` would fail regardless of the code.

## Verification

Verified on desktop against the dev server. Real camera access is blocked in the automated browser, so the success path was exercised by stubbing `getUserMedia` with a synthetic canvas stream: video mounted, stream attached, playing, `readyState` 4, 640×480; capturing a frame advanced the flow to the edit screen with the video correctly torn down. The unstubbed run exercised the failure path — error surfaced, no hung spinner, no crash.

**Not verified on a real device.** The stub deliberately bypasses the parts most likely to still bite on iPhone: the user-gesture requirement, back-camera selection, and real permission prompts. Needs a check on the deployed HTTPS URL before this is trusted.

## Note for the reviewer

The second commit is unrelated to the camera fix: it records ADR-0002 (architecture for the CHE-17 extraction feature), written during planning and committed here so it isn't left untracked. Happy to split it out if you'd rather it landed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)