### PR TITLE
Keep camera controls on screen and off the nav bar (CHE-18)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Switch, Route } from "wouter";
+import { Switch, Route, useLocation } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
@@ -13,9 +13,17 @@ import NotFound from "@/pages/not-found";
 import BottomNavigation from "@/components/bottom-navigation";
 
 function Router() {
+  const [location] = useLocation();
+
+  // Creating a session is a focused flow with its own back button, and the nav
+  // bar sits directly under the camera controls — a stray tap there both loses
+  // the work in progress and, on touch devices, catches the synthesized click
+  // that follows a capture.
+  const showBottomNavigation = location !== "/create-session";
+
   return (
     <div className="mobile-container max-w-sm mx-auto min-h-screen bg-background">
-      <div className="pb-20">
+      <div className={showBottomNavigation ? "pb-20" : undefined}>
         <Switch>
           <Route path="/" component={Sessions} />
           <Route path="/sessions" component={Sessions} />
@@ -26,7 +34,7 @@ function Router() {
           <Route component={NotFound} />
         </Switch>
       </div>
-      <BottomNavigation />
+      {showBottomNavigation && <BottomNavigation />}
     </div>
   );
 }

--- a/client/src/components/camera-capture.tsx
+++ b/client/src/components/camera-capture.tsx
@@ -53,7 +53,13 @@ export default function CameraCapture({ onImageCapture, onSkip }: CameraCaptureP
   };
 
   return (
-    <div className="px-4 py-8 flex flex-col items-center justify-center min-h-[60vh]">
+    <div
+      className={
+        isCameraActive
+          ? "px-4 py-4 flex flex-col items-center"
+          : "px-4 py-8 flex flex-col items-center justify-center min-h-[60vh]"
+      }
+    >
       {!isCameraActive ? (
         <>
           <div className="camera-frame w-64 h-48 flex flex-col items-center justify-center mb-6 border-2 border-dashed border-border rounded-lg bg-muted">
@@ -90,13 +96,18 @@ export default function CameraCapture({ onImageCapture, onSkip }: CameraCaptureP
         </>
       ) : (
         <>
-          <div className="relative w-full max-w-sm mb-6">
+          <div className="relative w-full max-w-sm mb-4">
+            {/* A portrait phone stream is far taller than it is wide, so cap the
+                height — unconstrained it pushes the capture button off screen.
+                Width stays fixed rather than hugging the video: `w-auto` has no
+                intrinsic size until stream metadata arrives and collapses the
+                frame in the meantime. */}
             <video
               ref={videoRef}
               autoPlay
               playsInline
               muted
-              className="w-full rounded-lg"
+              className="w-full max-h-[55vh] object-contain rounded-lg bg-black"
               data-testid="video-camera-feed"
             />
             {/* Selection overlay */}


### PR DESCRIPTION
Follow-up to #27, from testing on a real iPhone. The camera now launches and captures, but two problems showed up — and they share a root cause.

## What was wrong

**The capture button was off screen.** A portrait phone stream is much taller than it is wide, so an unconstrained `w-full` video rendered ~610px tall on a 375px-wide viewport. The button had to be scrolled to.

**Capturing landed you on Settings, with the PIN modal open.** That same overflow put the controls on top of the fixed bottom navigation, whose right half is the Settings button. The tap ran the capture, the video unmounted, the tall layout collapsed under the finger, and the `click` the browser synthesizes ~300ms after a touch landed on whatever was now at those coordinates. One tap, both effects.

## What changed

- **Cap the preview at 55vh** so the controls stay visible. The whole step now fits with no scrolling.
- **Hide the bottom navigation during session creation.** It's a focused flow with its own back button, and a stray tap there would discard work in progress regardless of the ghost click. Removing the target is what actually kills this failure mode — the height fix alone would leave it armed for any future layout shift.

## Verification

On a 375×812 mobile viewport with a synthetic 720×1280 portrait stream: video renders 343×447 instead of ~610 tall, capture button bottom at 604px against an 812px viewport, page not scrollable at all, no nav bar present in the create flow.

## One thing tried and backed out

I made the frame hug the video, to stop the letterboxing and keep the dashed alignment guide honest. It measured **2×2**: `w-auto` has no intrinsic width until stream metadata arrives, so the frame collapses in the interim. Fixed width stayed, with a comment recording why.

Known cosmetic issue left alone: the dashed guide spans the letterbox bars, so it slightly overstates the capture area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)