### PR TITLE
Add candidate sanitizer for extracted spelling lists (CHE-20)

### DIFF
--- a/client/src/lib/extraction-candidates.test.ts
+++ b/client/src/lib/extraction-candidates.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeExtractedCandidates } from "./extraction-candidates";
+
+const DEFAULT_TITLE = "Spelling Session 1/1/2026";
+
+describe("sanitizeExtractedCandidates", () => {
+  it("passes a single clean candidate through with title and words intact", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "Week 1", words: ["cat", "dog"] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates).toEqual([{ title: "Week 1", words: ["cat", "dog"] }]);
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it("passes several clean candidates through, in order", () => {
+    const result = sanitizeExtractedCandidates(
+      {
+        candidates: [
+          { title: "Week 1", words: ["cat"] },
+          { title: "Week 2", words: ["dog"] },
+        ],
+      },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates.map((c) => c.title)).toEqual(["Week 1", "Week 2"]);
+  });
+
+  it("keeps the non-blank entries of a candidate that has some blank entries", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "Week 1", words: ["cat", "  ", "", "dog"] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates).toEqual([{ title: "Week 1", words: ["cat", "dog"] }]);
+  });
+
+  it("drops a candidate whose entries are all blank", () => {
+    const result = sanitizeExtractedCandidates(
+      {
+        candidates: [
+          { title: "Empty", words: ["", "   "] },
+          { title: "Good", words: ["cat"] },
+        ],
+      },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates).toEqual([{ title: "Good", words: ["cat"] }]);
+  });
+
+  it("reports isEmpty when there are no candidates at all", () => {
+    const result = sanitizeExtractedCandidates({ candidates: [] }, DEFAULT_TITLE);
+    expect(result.isEmpty).toBe(true);
+    expect(result.candidates).toEqual([]);
+  });
+
+  it("reports isEmpty when every candidate is dropped", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "Empty", words: [] }, { title: "Also empty", words: ["  "] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.isEmpty).toBe(true);
+  });
+
+  it("does not report isEmpty when some candidates survive", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "Empty", words: [] }, { title: "Good", words: ["cat"] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.isEmpty).toBe(false);
+  });
+
+  it("falls back to the default title when a candidate's title is blank", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "   ", words: ["cat"] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates[0].title).toBe(DEFAULT_TITLE);
+  });
+
+  it("numbers distinguishable fallback titles when two candidates in a batch are both untitled", () => {
+    const result = sanitizeExtractedCandidates(
+      {
+        candidates: [
+          { title: "", words: ["cat"] },
+          { title: "", words: ["dog"] },
+        ],
+      },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates.map((c) => c.title)).toEqual([
+      `${DEFAULT_TITLE} (1)`,
+      `${DEFAULT_TITLE} (2)`,
+    ]);
+  });
+
+  it("leaves a real title supplied by the model alone even if it collides with another candidate's title", () => {
+    const result = sanitizeExtractedCandidates(
+      {
+        candidates: [
+          { title: "Week 1", words: ["cat"] },
+          { title: "Week 1", words: ["dog"] },
+        ],
+      },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates.map((c) => c.title)).toEqual(["Week 1", "Week 1"]);
+  });
+
+  it("passes multi-word phrases and full sentences through unchanged", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "Dictation", words: ["The quick brown fox.", "He said hello."] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates[0].words).toEqual(["The quick brown fox.", "He said hello."]);
+  });
+
+  it("passes Chinese entries through unchanged", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "听写", words: ["考一考", "苹果"] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates[0]).toEqual({ title: "听写", words: ["考一考", "苹果"] });
+  });
+
+  it("drops non-string values in the entries array without throwing", () => {
+    const result = sanitizeExtractedCandidates(
+      { candidates: [{ title: "Week 1", words: ["cat", 42, null, {}, ["nested"], "dog"] }] },
+      DEFAULT_TITLE,
+    );
+    expect(result.candidates[0].words).toEqual(["cat", "dog"]);
+  });
+
+  it("handles missing or null fields anywhere in the response without throwing", () => {
+    expect(() => sanitizeExtractedCandidates(null, DEFAULT_TITLE)).not.toThrow();
+    expect(() => sanitizeExtractedCandidates(undefined, DEFAULT_TITLE)).not.toThrow();
+    expect(() => sanitizeExtractedCandidates({}, DEFAULT_TITLE)).not.toThrow();
+    expect(() => sanitizeExtractedCandidates({ candidates: null }, DEFAULT_TITLE)).not.toThrow();
+    expect(() => sanitizeExtractedCandidates({ candidates: "oops" }, DEFAULT_TITLE)).not.toThrow();
+    expect(() =>
+      sanitizeExtractedCandidates({ candidates: [null, undefined, "oops", 5, {}] }, DEFAULT_TITLE),
+    ).not.toThrow();
+    expect(() =>
+      sanitizeExtractedCandidates({ candidates: [{ title: null, words: null }] }, DEFAULT_TITLE),
+    ).not.toThrow();
+
+    const result = sanitizeExtractedCandidates(null, DEFAULT_TITLE);
+    expect(result).toEqual({ candidates: [], isEmpty: true });
+  });
+});

--- a/client/src/lib/extraction-candidates.ts
+++ b/client/src/lib/extraction-candidates.ts
@@ -1,0 +1,68 @@
+export interface ExtractedCandidate {
+  title: string;
+  words: string[];
+}
+
+export interface SanitizeResult {
+  candidates: ExtractedCandidate[];
+  /** True when every candidate was dropped (or none arrived), so the caller
+   * should offer a fallback to manual entry rather than showing nothing. */
+  isEmpty: boolean;
+}
+
+/**
+ * Turns the model's raw extraction response into the candidates the UI should
+ * show. The response arrives shape-checked by the extraction endpoint's JSON
+ * schema, but this is the app's guard against a well-formed response carrying
+ * junk (blank entries, wrong types) — it never throws.
+ *
+ * Rules: entries are trimmed, blanks and non-strings dropped individually; a
+ * candidate is dropped only if nothing valid is left in it. Blank titles fall
+ * back to `defaultTitle`, numbered — "(1)", "(2)", ... — only when more than
+ * one candidate in the batch needs the fallback, so a single candidate's
+ * title isn't needlessly decorated.
+ */
+export function sanitizeExtractedCandidates(
+  raw: unknown,
+  defaultTitle: string,
+): SanitizeResult {
+  const rawCandidates = isRecord(raw) && Array.isArray(raw.candidates) ? raw.candidates : [];
+
+  const cleaned = rawCandidates
+    .map((candidate) => sanitizeOne(candidate))
+    .filter((candidate): candidate is Omit<ExtractedCandidate, "title"> & { title: string | null } =>
+      candidate !== null,
+    );
+
+  const fallbackCount = cleaned.filter((c) => c.title === null).length;
+  let fallbackIndex = 0;
+
+  const candidates = cleaned.map(({ title, words }) => {
+    if (title !== null) return { title, words };
+    fallbackIndex += 1;
+    return {
+      title: fallbackCount > 1 ? `${defaultTitle} (${fallbackIndex})` : defaultTitle,
+      words,
+    };
+  });
+
+  return { candidates, isEmpty: candidates.length === 0 };
+}
+
+/** Sanitizes one candidate, or returns null if it has no valid words left. */
+function sanitizeOne(candidate: unknown): { title: string | null; words: string[] } | null {
+  if (!isRecord(candidate)) return null;
+
+  const words = Array.isArray(candidate.words)
+    ? candidate.words.filter((w): w is string => typeof w === "string").map((w) => w.trim()).filter((w) => w.length > 0)
+    : [];
+
+  if (words.length === 0) return null;
+
+  const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
+  return { title: title.length > 0 ? title : null, words };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
The one test seam for CHE-17 (image-to-spelling-list). A pure function that turns the extraction endpoint's raw response into the candidates the UI should show, plus a signal for whether everything ended up empty.

## Why this exists

The endpoint's JSON schema (CHE-19) shape-checks the response, but a schema can't stop a well-formed reply from carrying junk — blank strings, a stray non-string value. This function is the guard against that. It never throws.

## Rules

- Entries are trimmed; blanks and non-strings dropped individually.
- A candidate is dropped only if nothing valid is left in it — one bad entry doesn't sink an otherwise-good candidate.
- A blank title falls back to a caller-supplied default, **numbered only when more than one candidate in the batch needs the fallback** — a single untitled candidate doesn't get a needless "(1)".
- Entries are preserved exactly as given: no case-folding, no punctuation stripping, no whitespace splitting. This is the deliberate opposite of the old Tesseract path, which did all three and would mangle phrases, sentences, and Chinese characters — all of which extraction now needs to carry intact.

## Prior art

Matches `session-mode.ts` / `pinyin.ts`: a small pure module in `client/src/lib`, test file beside it, plain vitest, no DOM, no mocks.

## Testing

14 tests, one per acceptance criterion in the ticket: clean single/multiple candidates, partial and total blank-entry drops, the `isEmpty` signal in both directions, title fallback with and without numbering, phrases/sentences/Chinese passing through unchanged, and non-string/null/missing values at every level of the response handled without throwing.

```
Test Files  1 passed (1)
     Tests  14 passed (14)
```

Full suite (24 tests) and `tsc --noEmit` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)