### PR TITLE
Remove Recent Sessions header from main page (CHE-36)

### DIFF
--- a/client/src/pages/sessions.tsx
+++ b/client/src/pages/sessions.tsx
@@ -93,11 +93,6 @@ export default function Sessions() {
 
       {/* Content */}
       <div className="px-4 py-4">
-        {/* Recent Sessions */}
-        <div className="mb-4">
-          <h2 className="text-lg font-semibold text-foreground mb-3">Recent Sessions</h2>
-        </div>
-
         {isLoading ? (
           <div className="space-y-3">
             {[...Array(5)].map((_, i) => (


### PR DESCRIPTION
## What

Removed the redundant "Recent Sessions" heading from the sessions page — the list now starts directly under the header.

## Testing

- `tsc` clean
- 24/24 vitest tests passing

Linear: https://linear.app/cherndevs/issue/CHE-36/remove-recent-sessions-header-in-the-main-page

🤖 Generated with [Claude Code](https://claude.com/claude-code)